### PR TITLE
Add tab sepstring to awk invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ It gets a little more complicated, though.  You have to break up the single-line
 Let's check out some example pipelines.  Suppose your deck uses the SM-2 algorithm and you want reviews to have at most 20 old cards and 10 new ones.  If you want to review the cards on the console using fields two and three as the front and back, respectively, then this Bourne shell code will do it:
 
     mkfifo -m 0700 cardpipe commandpipe
-    ( osm2 -n 20 -e 10 deck.log <deck.txt | oboeta -2 $commandpipe deck.log | awk '{
+    ( osm2 -n 20 -e 10 deck.log <deck.txt | oboeta -2 $commandpipe deck.log | awk -F \\t '{
       print $2
       print $3
       system("")  # to flush awk's stdout buffer
@@ -105,7 +105,7 @@ The -2 flags enable SM-2 support in `oboeta` and `oboetatty`.
 If you want to review cards via your favorite web browser, then do this instead:
 
     mkfifo -m 0700 commandpipe
-    osm2 -n 20 -e 10 deck.log <deck.txt | oboeta -2 $commandpipe deck.log | awk '{
+    osm2 -n 20 -e 10 deck.log <deck.txt | oboeta -2 $commandpipe deck.log | awk -F \\t '{
       print $2
       print $3
       system("")  # to flush awk's stdout buffer


### PR DESCRIPTION
Problem: in addition to tabs awk treats spaces as field separators