### PR TITLE
Fix SM-2 implementation

### DIFF
--- a/osm2.py
+++ b/osm2.py
@@ -97,7 +97,7 @@ class TLine(object):
     else:
       self.intervalnum += 1
       self.duedate = now + timedelta(days=self.interval)
-      self.interval = (6 if self.intervalnum == 2 else ceil(self.interval + self.ef))
+      self.interval = (6 if self.intervalnum == 2 else ceil(self.interval * self.ef))
     self.ef = max(self.ef + 0.1 - (5 - q) * (0.08 + 0.02 * (5 - q)), 1.3)
 
 # Check arguments for illegal values.


### PR DESCRIPTION
The SM-2 page on Wikipedia states that "    interval = interval * easiness" when repetitions (intervalnum in osm2.py) is >1, but the implementation here used interval + easiness instead.